### PR TITLE
Changes to setup to enable installation via pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ REQUIREMENTS = [i.strip() for i in open("requirements.txt").readlines()] # pragm
 
 setup(name='Djest',
       version='0.1',
-      py_modules=['djest'],
+      packages=['djest'],
       cmdclass={'upload':lambda x:None},
       install_requires=[
           'django',


### PR DESCRIPTION
Wanted to include djest as a dependency when running with pip -r and had some problems building the package and installing. Fixes for those issues are attached, and enable making a package with "python setup.py sdist"
